### PR TITLE
Bump PHP dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     ]
   },
   "phpDependencies": {
-    "roots/bedrock": "1.7.4",
-    "timber/timber": "~1.1",
-    "flyntwp/flynt-core": "dev-master",
+    "roots/bedrock": "1.7.7",
+    "timber/timber": "1.2.4",
+    "flyntwp/flynt-core": "1.0.0",
     "flyntwp/acf-field-group-composer": "1.0.0",
     "composer/installers": "^1.0",
     "philippbaschke/acf-pro-installer": "^1.0",


### PR DESCRIPTION
update bedrock version, set flynt core version, set timber version to 1.2.4 (currently there are issues with 1.3)