### PR TITLE
fix(Clone DB): Fixed Clone DB having issues on Ubuntu 16.04 and higher

### DIFF
--- a/lib/clone/db.js
+++ b/lib/clone/db.js
@@ -80,7 +80,7 @@ function run(answers) {
   if (sourceRemote) {
     cmds.push('scp ' + (answers.sshPort ? '-P ' + answers.sshPort : '') + ' ' + sourceSshId + ':' + answers.basePath + '/' + tmpDir + '/' + backupTransferFile + ' ' + tmpDir);
   }
-  cmds.push('sed -i \'\' \'s/DEFINER=[^*]*\\*/\\*/g\' ' + tmpDir + '/' + backupTransferFile);
+  cmds.push('sed -i \'s/DEFINER=[^*]*\\*/\\*/g\' ' + tmpDir + '/' + backupTransferFile);
   if (destinationRemote) {
     cmds.push('scp ' + (answers.sshPortRemote ? '-P ' + answers.sshPortRemote : '') + ' ' + tmpDir + '/' + backupTransferFile + ' ' + destinationSshId + ':' + answers.basePathRemote + '/' + tmpDir);
     cmds.push('rm ' + tmpDir + '/' + backupTransferFile);

--- a/src/clone/db.js
+++ b/src/clone/db.js
@@ -82,7 +82,7 @@ export function run (answers) {
   if (sourceRemote) {
     cmds.push(`scp ${answers.sshPort ? `-P ${answers.sshPort}` : ''} ${sourceSshId}:${answers.basePath}/${tmpDir}/${backupTransferFile} ${tmpDir}`)
   }
-  cmds.push(`sed -i '' 's/DEFINER=[^*]*\\*/\\*/g' ${tmpDir}/${backupTransferFile}`)
+  cmds.push(`sed -i 's/DEFINER=[^*]*\\*/\\*/g' ${tmpDir}/${backupTransferFile}`)
   if (destinationRemote) {
     cmds.push(`scp ${answers.sshPortRemote ? `-P ${answers.sshPortRemote}` : ''} ${tmpDir}/${backupTransferFile} ${destinationSshId}:${answers.basePathRemote}/${tmpDir}`)
     cmds.push(`rm ${tmpDir}/${backupTransferFile}`)


### PR DESCRIPTION
Fixed bug caused by sed's first, empty argument which is not valid (see sed manual) - Needs testing
on OSX first though

clone db not being usable on Linux hosts