### PR TITLE
Fixed broken Composer versioning for ACF Pro Installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "flyntwp/acf-field-group-composer": "^1.0.0",
     "composer/installers": "^1.0",
     "philippbaschke/acf-pro-installer": "^1.0",
-    "advanced-custom-fields/advanced-custom-fields-pro": "~5.6.10"
+    "advanced-custom-fields/advanced-custom-fields-pro": "5.6.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "flyntwp/acf-field-group-composer": "^1.0.0",
     "composer/installers": "^1.0",
     "philippbaschke/acf-pro-installer": "^1.0",
-    "advanced-custom-fields/advanced-custom-fields-pro": "5.6.10"
+    "advanced-custom-fields/advanced-custom-fields-pro": "5.7.7"
   }
 }


### PR DESCRIPTION
I found out that the versioning change in the package.json lead to the `flynt create` task to break on the composer installation task. Fixes #79 but needs a check for the future. Maybe it's a system difference between MacOS and Windows and how Composer reads the versioning informations in the composer.json.

I had no problems installing a new Flynt project with this change/rollback.