### PR TITLE
feat(gitignore, deploy): adjust excludes

### DIFF
--- a/src/create/adjustGitignore.js
+++ b/src/create/adjustGitignore.js
@@ -30,7 +30,11 @@ function getLinesToAdd () {
     '.gitignore': {
       lines: [
         '/tmp/',
-        '/backup/'
+        '/backup/',
+        'web/app/wflogs',
+        'web/app/cache',
+        'web/app/advanced-cache.php',
+        'web/app/wp-cache-config.php'
       ],
       prepend: true
     }

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -98,6 +98,7 @@ export const deployExcludes = {
     '/.env.example',
     '/.env',
     '/.flynt.json',
+    '/.vscode',
     '/backup',
     '/CHANGELOG.md',
     '/LICENSE.md',
@@ -109,7 +110,11 @@ export const deployExcludes = {
     '/web/.htpasswd',
     '/web/app/uploads',
     '/web/usage',
-    'node_modules'
+    'node_modules',
+    '/web/app/advanced-cache.php',
+    '/web/app/wp-cache-config.php',
+    '/web/app/cache',
+    '/web/app/wflogs'
   ]),
   filter: filterJsonArray
 }


### PR DESCRIPTION
now ignores Wordfence log files, WP Super Cache files and .vscode settings (on deploy)